### PR TITLE
Handle Django 1.8 get_language() returning None

### DIFF
--- a/transmeta/__init__.py
+++ b/transmeta/__init__.py
@@ -17,8 +17,10 @@ def get_languages():
 
 
 def get_real_fieldname(field, lang=None):
+    """ append lang to base field name. Use active or fallback language if lang is None """
     if lang is None:
-        lang = get_language().split('-')[0]  # both 'en-US' and 'en' -> 'en'
+        lang = get_language() or fallback_language()
+        lang = lang.split('-')[0] # both 'en-US' and 'en' -> 'en'
     return str('%s_%s' % (field, lang))
 
 


### PR DESCRIPTION
- Django 1.8 get_language() returns None if there are no active translations, 
  previously returned LANGUAGE_CODE
- TransMeta requires a value for lang, and already has fallback_language()
  so use that in get_real_fieldname if both param lang and get_language()
  are None
