### PR TITLE
Changed SortedDict to OrderedDict since it will be removed in Django 1.9

### DIFF
--- a/transmeta/__init__.py
+++ b/transmeta/__init__.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.db.models.fields import NOT_PROVIDED
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.datastructures import SortedDict
+from collections import OrderedDict
 from django.utils.translation import get_language, ugettext_lazy as _
 
 
@@ -113,7 +113,7 @@ class TransMeta(models.base.ModelBase):
     '''
 
     def __new__(cls, name, bases, attrs):
-        attrs = SortedDict(attrs)
+        attrs = OrderedDict(attrs)
         if 'Meta' in attrs and hasattr(attrs['Meta'], 'translate'):
             fields = attrs['Meta'].translate
             delattr(attrs['Meta'], 'translate')


### PR DESCRIPTION
See: https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.datastructures.SortedDict
